### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/forketyfork/hibernate-extended-enhancement/security/code-scanning/1](https://github.com/forketyfork/hibernate-extended-enhancement/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the steps in the workflow, the `contents: read` permission is sufficient, as the workflow only reads repository contents and does not perform any write operations.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `test` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
