### PR TITLE
build(deps): pin Hibernate to 6.6 line and migrate to jakarta.persistence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This is a demonstration project for Hibernate Extended Bytecode Enhancement, acc
 
 ## Build System & Commands
 
-This is a Maven-based Java project using Java 14.
+This is a Maven-based Java project using Java 21.
 
 ### Essential Commands
 - **Build**: `mvn clean compile`
@@ -17,9 +17,13 @@ This is a Maven-based Java project using Java 14.
 - **Clean**: `mvn clean`
 
 ### Dependencies
-- Hibernate Core 5.6.15.Final
-- H2 Database 2.3.232 (for testing)
-- JUnit Jupiter 5.13.4 (for testing)
+- Hibernate Core 6.6.51.Final
+- H2 Database 2.4.240 (for testing)
+- JUnit Jupiter 6.1.0 (for testing)
+
+The project is pinned to the Hibernate 6.6 line because extended bytecode
+enhancement is deprecated in Hibernate 7.x. See `README.md` for the upstream
+deprecation note.
 
 ## Architecture
 
@@ -42,7 +46,7 @@ The project demonstrates Hibernate's extended enhancement feature through:
 The Maven build uses `hibernate-enhance-maven-plugin` with:
 - `enableDirtyTracking=true`: Tracks which fields have been modified
 - `enableExtendedEnhancement=true`: Detects field changes even when setters aren't used
-- Version 6.6.22.Final (newer than core Hibernate for enhanced features)
+- Plugin version matches `hibernate-core` (6.6.51.Final)
 
 ### Test Database Setup
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,20 @@
 [![Java](https://img.shields.io/badge/language-Java-orange.svg)](https://www.oracle.com/java/)
 
 Source code for the article [Hibernate Extended Bytecode Enhancement](https://medium.com/@forketyfork/hibernate-extended-bytecode-enhancement-ae73962c9bf4)
+
+## Deprecation notice
+
+Extended bytecode enhancement has been deprecated in Hibernate 7. The
+[Hibernate 7.3 User Guide](https://docs.hibernate.org/orm/7.3/userguide/html_single/Hibernate_User_Guide.html#BytecodeEnhancement-dirty-tracking)
+states:
+
+> Hibernate's extended bytecode enhancement feature has been deprecated,
+> primarily because it relies on assumptions and behaviors that often require
+> a broader runtime scope than what Hibernate alone can reliably provide,
+> similar to container-based environments such as Quarkus or WildFly.
+> Applications which make use of this feature should instead use proper
+> object-oriented encapsulation, exposing managed state via getters and
+> setters.
+
+This project is therefore pinned to the Hibernate 6.6 line, where extended
+enhancement is still fully supported.

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
-      <version>5.6.15.Final</version>
+      <version>6.6.51.Final</version>
     </dependency>
 
     <dependency>
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>6.0.3</version>
+      <version>6.1.0</version>
       <scope>test</scope>
     </dependency>
 
@@ -58,7 +58,7 @@
       <plugin>
         <groupId>org.hibernate.orm.tooling</groupId>
         <artifactId>hibernate-enhance-maven-plugin</artifactId>
-        <version>6.6.50.Final</version>
+        <version>6.6.51.Final</version>
         <executions>
           <execution>
             <configuration>

--- a/src/main/java/com/forketyfork/hibernate/Cat.java
+++ b/src/main/java/com/forketyfork/hibernate/Cat.java
@@ -1,10 +1,10 @@
 package com.forketyfork.hibernate;
 
 import java.io.Serializable;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
 
 @Entity
 public class Cat implements Serializable {


### PR DESCRIPTION
## Summary

Dependabot PR #54 bumped hibernate-core to 7.3.6.Final, but Hibernate 7 deprecates extended bytecode enhancement, which is the feature this demo is built around. The 7.3 user guide states (section 6.2.2):

> Hibernate's extended bytecode enhancement feature has been deprecated, primarily because it relies on assumptions and behaviors that often require a broader runtime scope than what Hibernate alone can reliably provide, similar to container-based environments such as Quarkus or WildFly. Applications which make use of this feature should instead use proper object-oriented encapsulation, exposing managed state via getters and setters.

The 6.6 user guide has no such note, and there is also no stable 7.x release of `hibernate-enhance-maven-plugin` (only `7.0.0.Beta1`).

This PR keeps the junit and enhance-plugin bumps from #54 but pins `hibernate-core` to the latest stable 6.6 release (6.6.51.Final) so the demo stays on a line where extended enhancement is officially supported. Required source changes:

- `Cat.java`: migrate `javax.persistence` to `jakarta.persistence` (mandatory since Hibernate 6)
- `README.md`: quote the upstream deprecation message so readers of the linked Medium article know about the change in 7.x
- `CLAUDE.md`: correct stale Java/dependency version references

Once this lands, Dependabot PR #54 can be closed.

## Test plan

- [ ] Confirm the SQL log of `mvn test` shows two `update Cat set name=?` statements (one after `myCustomMethodToChangeData()`, one after `SneakyCatService.patACat()`), proving extended enhancement still detects direct field writes.
- [ ] Skim the new README deprecation note for tone and accuracy of the quote.
